### PR TITLE
Use paths and schemas instead of functions in migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Universi is heavily inspired by this approach so let's continue our tutorial and
 
 ### Creating the Migration
 
-We need to create a migration to handle changes between these versions. This migration will convert the list of addresses back to a single address when migrating to the previous version. Yes, migrating **back**: you might be used to database migrations where we write upgrade migration and downgrade migration but here our goal is to have an app of latest version and to describe what older versions looked like in comparison to it. That way the old versions are frozen in migrations and you can **almost** safely forget about them.
+We need to create a migration to handle changes between these versions. For every endpoint whose `response_model` is `UserResource`, this migration will convert the list of addresses back to a single address when migrating to the previous version. Yes, migrating **back**: you might be used to database migrations where we write upgrade migration and downgrade migration but here our goal is to have an app of latest version and to describe what older versions looked like in comparison to it. That way the old versions are frozen in migrations and you can **almost** safely forget about them.
 
 ```python
 from universi import Field
@@ -153,7 +153,7 @@ class ChangeAddressToList(VersionChange):
         schema(UserResource).field("address").existed_with(type=str, info=Field()),
     )
 
-    @convert_response_to_previous_version_for(get_user, create_user)
+    @convert_response_to_previous_version_for(UserResource)
     def change_addresses_to_single_item(cls, data: dict[str, Any]) -> None:
         data["address"] = data.pop("addresses")[0]
     
@@ -242,7 +242,7 @@ from universi.structure import VersionChange, endpoint
 class MyChange(VersionChange):
     description = "..."
     instructions_to_migrate_to_previous_version = (
-        endpoint(my_old_endpoint).existed,
+        endpoint("/my_old_endpoint").existed,
     )
 
 ```
@@ -257,7 +257,7 @@ from universi.structure import VersionChange, endpoint
 class MyChange(VersionChange):
     description = "..."
     instructions_to_migrate_to_previous_version = (
-        endpoint(my_new_endpoint).didnt_exist,
+        endpoint("/my_new_endpoint").didnt_exist,
     )
 
 ```
@@ -272,7 +272,7 @@ from universi.structure import VersionChange, endpoint
 class MyChange(VersionChange):
     description = "..."
     instructions_to_migrate_to_previous_version = (
-        endpoint(my_endpoint).had(description="My old description"),
+        endpoint("/my_endpoint").had(description="My old description"),
     )
 
 ```
@@ -404,7 +404,7 @@ MySchema = (
 and you would be able to use it like so:
 
 ```python
-from src.versions.unions.my_schema_module import MySchema
+from src.schemas.unions.my_schema_module import MySchema
 
 async def the_entrypoint_of_my_business_logic(request_payload: MySchema):
     ...
@@ -424,13 +424,13 @@ from typing import Any
 class ChangeAddressToList(VersionChange):
     description = "..."
 
-    @convert_response_to_previous_version_for(my_endpoint, my_other_endpoint)
+    @convert_response_to_previous_version_for(MyEndpointResponseModel)
     def change_addresses_to_single_item(cls, data: dict[str, Any]) -> None:
         data["address"] = data.pop("addresses")[0]
 
 ```
 
-It is done by applying `universi.VersionBundle.versioned(...)` decorator to each endpoint which automatically detects the API version by getting it from the [contextvar](#api-version-header-and-context-variables) and applying all version changes until the selected version in reverse. Note that if the version is not set, then no changes will be applied.
+It is done by applying `universi.VersionBundle.versioned(...)` decorator to each endpoint with the given `response_model` which automatically detects the API version by getting it from the [contextvar](#api-version-header-and-context-variables) and applying all version changes until the selected version in reverse. Note that if the version is not set, then no changes will be applied.
 
 If you want to convert a specific response to a specific version, you can use `universi.VersionBundle.data_to_version(...)`.
 
@@ -475,6 +475,8 @@ async def create_user(payload):
 So this change can be contained in any version -- your business logic doesn't know which version it has and shouldn't.
 
 ### API Version header and context variables
+
+**Note that this behavior is deprecated. Only use a custom contextvar that you made yourself**
 
 Universi automatically converts your data to a correct version and has "version checks" when dealing with side effects as described in [the section above](#version-changes-with-side-effects). It can only do so using a special [context variable](https://docs.python.org/3/library/contextvars.html) that stores the current API version.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "universi"
-version = "1.3.6"
+version = "1.4.0"
 description = "Modern Stripe-like API versioning in FastAPI"
 authors = ["Stanislav Zmiev <zmievsa@gmail.com>"]
 license = "MIT"

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -38,9 +38,14 @@ def router() -> VersionedAPIRouter:
 
 
 @pytest.fixture()
-def test_endpoint(router: VersionedAPIRouter) -> Endpoint:
-    @router.get("/test")
-    async def test():
+def test_path() -> str:
+    return "/test/{hewoo}"
+
+
+@pytest.fixture()
+def test_endpoint(router: VersionedAPIRouter, test_path: str) -> Endpoint:
+    @router.get(test_path)
+    async def test(hewwo: int):
         raise NotImplementedError
 
     return test
@@ -99,10 +104,10 @@ def test__router_generation__forgot_to_generate_schemas__error(
         create_versioned_api_routes(router, latest_schemas_module=latest)
 
 
-def test__endpoint_didnt_exist(router: VersionedAPIRouter, test_endpoint: Endpoint):
+def test__endpoint_didnt_exist(router: VersionedAPIRouter, test_endpoint: Endpoint, test_path: str):
     routes_2000, routes_2001 = create_versioned_api_routes(
         router,
-        endpoint(test_endpoint).didnt_exist,
+        endpoint(test_path).didnt_exist,
     )
 
     assert routes_2000 == []
@@ -119,7 +124,7 @@ def test__endpoint_existed(router: VersionedAPIRouter):
 
     routes_2000, routes_2001 = create_versioned_api_routes(
         router,
-        endpoint(test_endpoint).existed,
+        endpoint("/test").existed,
     )
 
     assert len(routes_2000) == 1
@@ -156,10 +161,11 @@ def test__endpoint_had(
     attr: str,
     attr_value: Any,
     test_endpoint: Endpoint,
+    test_path: str,
 ):
     routes_2000, routes_2001 = create_versioned_api_routes(
         router,
-        endpoint(test_endpoint).had(**{attr: attr_value}),
+        endpoint(test_path).had(**{attr: attr_value}),
     )
 
     assert len(routes_2000) == len(routes_2001) == 1
@@ -184,12 +190,13 @@ def test__endpoint_only_exists_in_older_versions__endpoint_is_not_a_route__error
 def test__router_generation__non_api_route_added(
     router: VersionedAPIRouter,
     test_endpoint: Endpoint,
+    test_path: str,
 ):
     @router.websocket("/test2")
     async def test_websocket():
         raise NotImplementedError
 
-    routers = create_versioned_copies(router, endpoint(test_endpoint).didnt_exist)
+    routers = create_versioned_copies(router, endpoint(test_path).didnt_exist)
     assert len(routers[date(2000, 1, 1)].routes) == 1
     assert len(routers[date(2001, 1, 1)].routes) == 2
     route = routers[date(2001, 1, 1)].routes[0]
@@ -208,7 +215,7 @@ def test__router_generation__creating_a_synchronous_endpoint__error(
         TypeError,
         match=re.escape("All versioned endpoints must be asynchronous."),
     ):
-        create_versioned_copies(router, endpoint(test).didnt_exist)
+        create_versioned_copies(router, endpoint("/test").didnt_exist)
 
 
 def test__router_generation__changing_a_deleted_endpoint__error(
@@ -222,10 +229,10 @@ def test__router_generation__changing_a_deleted_endpoint__error(
     with pytest.raises(
         RouterGenerationError,
         match=re.escape(
-            "Endpoint 'test' you tried to delete in 'MyVersionChange' doesn't exist in new version",
+            "Endpoint '/test' you tried to delete in 'MyVersionChange' doesn't exist in new version",
         ),
     ):
-        create_versioned_copies(router, endpoint(test).had(description="Hewwo"))
+        create_versioned_copies(router, endpoint("/test").had(description="Hewwo"))
 
 
 def test__router_generation__deleting_a_deleted_endpoint__error(
@@ -239,23 +246,24 @@ def test__router_generation__deleting_a_deleted_endpoint__error(
     with pytest.raises(
         RouterGenerationError,
         match=re.escape(
-            "Endpoint 'test' you tried to delete in 'MyVersionChange' doesn't exist in new version",
+            "Endpoint '/test' you tried to delete in 'MyVersionChange' doesn't exist in new version",
         ),
     ):
-        create_versioned_copies(router, endpoint(test).didnt_exist)
+        create_versioned_copies(router, endpoint("/test").didnt_exist)
 
 
 def test__router_generation__re_creating_an_existing_endpoint__error(
     router: VersionedAPIRouter,
     test_endpoint: Endpoint,
+    test_path: str,
 ):
     with pytest.raises(
         RouterGenerationError,
         match=re.escape(
-            "Endpoint 'test' you tried to re-create in 'MyVersionChange' already existed in newer versions",
+            "Endpoint '/test/{hewoo}' you tried to re-create in 'MyVersionChange' already existed in newer versions",
         ),
     ):
-        create_versioned_copies(router, endpoint(test_endpoint).existed)
+        create_versioned_copies(router, endpoint(test_path).existed)
 
 
 def get_nested_field_type(annotation: Any) -> type[BaseModel]:
@@ -265,21 +273,19 @@ def get_nested_field_type(annotation: Any) -> type[BaseModel]:
 def test__router_generation__re_creating_a_non_endpoint__error(
     router: VersionedAPIRouter,
 ):
-    async def test():
-        raise NotImplementedError
-
     with pytest.raises(
         RouterGenerationError,
         match=re.escape(
-            "Endpoint 'test' you tried to re-create in 'MyVersionChange' wasn't among the deleted routes",
+            "Endpoint '/test' you tried to re-create in 'MyVersionChange' wasn't among the deleted routes",
         ),
     ):
-        create_versioned_copies(router, endpoint(test).existed)
+        create_versioned_copies(router, endpoint("/test").existed)
 
 
 def test__router_generation__changing_attribute_to_the_same_value__error(
     router: VersionedAPIRouter,
     test_endpoint: Endpoint,
+    test_path: str,
 ):
     with pytest.raises(
         RouterGenerationError,
@@ -288,12 +294,13 @@ def test__router_generation__changing_attribute_to_the_same_value__error(
             " It means that your version change has no effect on the attribute and can be removed.",
         ),
     ):
-        create_versioned_copies(router, endpoint(test_endpoint).had(path="/test"))
+        create_versioned_copies(router, endpoint(test_path).had(path=test_path))
 
 
 def test__router_generation__non_api_route_added_with_schemas(
     router: VersionedAPIRouter,
     test_endpoint: Endpoint,
+    test_path: str,
 ):
     @router.websocket("/test2")
     async def test_websocket():
@@ -302,7 +309,7 @@ def test__router_generation__non_api_route_added_with_schemas(
     generate_test_version_packages()
     routers = create_versioned_copies(
         router,
-        endpoint(test_endpoint).didnt_exist,
+        endpoint(test_path).didnt_exist,
         latest_schemas_module=latest,
     )
     assert len(routers[date(2000, 1, 1)].routes) == 1
@@ -413,14 +420,14 @@ def test__router_generation__using_unversioned_models(
     )
 
     assert len(routes_2000) == len(routes_2001) == 3
-    assert routes_2000[0].dependant.body_params[0].annotation is UnversionedSchema1
-    assert routes_2001[0].dependant.body_params[0].annotation is UnversionedSchema1
+    assert routes_2000[0].dependant.body_params[0].type_ is UnversionedSchema1
+    assert routes_2001[0].dependant.body_params[0].type_ is UnversionedSchema1
 
-    assert routes_2000[1].dependant.body_params[0].annotation is UnversionedSchema2
-    assert routes_2001[1].dependant.body_params[0].annotation is UnversionedSchema2
+    assert routes_2000[1].dependant.body_params[0].type_ is UnversionedSchema2
+    assert routes_2001[1].dependant.body_params[0].type_ is UnversionedSchema2
 
-    assert routes_2000[2].dependant.body_params[0].annotation is UnversionedSchema3
-    assert routes_2001[2].dependant.body_params[0].annotation is UnversionedSchema3
+    assert routes_2000[2].dependant.body_params[0].type_ is UnversionedSchema3
+    assert routes_2001[2].dependant.body_params[0].type_ is UnversionedSchema3
 
 
 def test__router_generation__using_weird_typehints(
@@ -552,7 +559,7 @@ def test__cascading_router_exists(router: VersionedAPIRouter):
 
     class V2002(VersionChange):
         description = ""
-        instructions_to_migrate_to_previous_version = [endpoint(test_with_dep1).existed]
+        instructions_to_migrate_to_previous_version = [endpoint("/test").existed]
 
     versions = VersionBundle(
         Version(date(2002, 1, 1), V2002),
@@ -579,7 +586,7 @@ def test__cascading_router_didnt_exist(router: VersionedAPIRouter):
     class V2002(VersionChange):
         description = ""
         instructions_to_migrate_to_previous_version = [
-            endpoint(test_with_dep1).didnt_exist,
+            endpoint("/test").didnt_exist,
         ]
 
     versions = VersionBundle(

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -1,6 +1,7 @@
 import re
 from datetime import date
 from typing import Any
+from pydantic import BaseModel
 
 import pytest
 
@@ -259,8 +260,8 @@ def test__versions__one_version_change_attached_to_two_versions__error(
 
 
 def test__conversion_method__with_incorrect_structure():
-    async def some_endpoint():
-        raise NotImplementedError
+    class SomeSchema(BaseModel):
+        pass
 
     with pytest.raises(
         ValueError,
@@ -269,7 +270,7 @@ def test__conversion_method__with_incorrect_structure():
         ),
     ):
 
-        @convert_response_to_previous_version_for(some_endpoint)
+        @convert_response_to_previous_version_for(SomeSchema)
         def my_conversion_method(cls: Any, response: Any):
             raise NotImplementedError
 
@@ -280,6 +281,6 @@ def test__conversion_method__with_incorrect_structure():
         ),
     ):
 
-        @convert_response_to_previous_version_for(some_endpoint)  # pyright: ignore[reportGeneralTypeIssues]
+        @convert_response_to_previous_version_for(SomeSchema)  # pyright: ignore[reportGeneralTypeIssues]
         def my_conversion_method2():
             raise NotImplementedError

--- a/tests/test_tutorial/test_users_example001/users.py
+++ b/tests/test_tutorial/test_users_example001/users.py
@@ -44,7 +44,7 @@ class ChangeAddressToList(VersionChange):
         schema(UserResource).field("address").existed_with(type=str, info=Field()),
     )
 
-    @convert_response_to_previous_version_for(get_user, create_user)
+    @convert_response_to_previous_version_for(UserResource)
     def change_addresses_to_single_item(cls, data: dict[str, Any]) -> None:
         data["address"] = data.pop("addresses")[0]
 

--- a/tests/test_tutorial/test_users_example002/users.py
+++ b/tests/test_tutorial/test_users_example002/users.py
@@ -55,7 +55,7 @@ class ChangeAddressToList(VersionChange):
         schema(UserResource).field("address").existed_with(type=str, info=Field()),
     )
 
-    @convert_response_to_previous_version_for(get_user, create_user)
+    @convert_response_to_previous_version_for(UserResource)
     def change_addresses_to_single_item(cls, data: dict[str, Any]) -> None:
         data["address"] = data.pop("addresses")[0]
 
@@ -70,10 +70,10 @@ class ChangeAddressesToSubresource(VersionChange):
         schema(UserCreateRequest).field("addresses").existed_with(type=list[str], info=Field()),
         schema(UserCreateRequest).field("default_address").didnt_exist,
         schema(UserResource).field("addresses").existed_with(type=list[str], info=Field()),
-        endpoint(get_user_addresses).didnt_exist,
+        endpoint("/users/{user_id}/addresses").didnt_exist,
     )
 
-    @convert_response_to_previous_version_for(get_user, create_user)
+    @convert_response_to_previous_version_for(UserResource)
     def change_addresses_to_list(cls, data: dict[str, Any]) -> None:
         data["addresses"] = [id["value"] for id in data.pop("_prefetched_addresses")]
 

--- a/tests/test_tutorial/test_users_example003/users.py
+++ b/tests/test_tutorial/test_users_example003/users.py
@@ -45,7 +45,7 @@ class ChangeAddressToList(VersionChange):
         schema(UserResource).field("address").existed_with(type=str, info=Field()),
     )
 
-    @convert_response_to_previous_version_for(get_user, create_user)
+    @convert_response_to_previous_version_for(UserResource)
     def change_addresses_to_single_item(cls, data: dict[str, Any]) -> None:
         data["address"] = data.pop("addresses")[0]
 
@@ -60,10 +60,10 @@ class ChangeAddressesToSubresource(VersionChange):
         schema(UserCreateRequest).field("addresses").existed_with(type=list[str], info=Field()),
         schema(UserCreateRequest).field("default_address").didnt_exist,
         schema(UserResource).field("addresses").existed_with(type=list[str], info=Field()),
-        endpoint(get_user_addresses).didnt_exist,
+        endpoint("/users/{user_id}/addresses").didnt_exist,
     )
 
-    @convert_response_to_previous_version_for(get_user, create_user)
+    @convert_response_to_previous_version_for(UserResource)
     def change_addresses_to_list(cls, data: dict[str, Any]) -> None:
         data["addresses"] = [id["value"] for id in data.pop("_prefetched_addresses")]
 

--- a/universi/codegen.py
+++ b/universi/codegen.py
@@ -573,7 +573,8 @@ def custom_repr(value: Any) -> Any:
         # This is a hack for pydantic's Constrained types
         if value.__name__.startswith("Constrained"):
             # No, get_origin and get_args don't work here. No idea why
-            return custom_repr(value.__origin__[value.__args__])
+            origin, args = value.__origin__, value.__args__  # pyright: ignore[reportGeneralTypeIssues]
+            return custom_repr(origin[args])
         return value.__name__
     if isinstance(value, Enum):
         return PlainRepr(f"{value.__class__.__name__}.{value.name}")

--- a/universi/structure/endpoints.py
+++ b/universi/structure/endpoints.py
@@ -52,31 +52,31 @@ class EndpointAttributesPayload:
 
 @dataclass(slots=True)
 class EndpointHadInstruction:
-    endpoint: Endpoint
+    endpoint_path: str
     attributes: EndpointAttributesPayload
 
 
 @dataclass(slots=True)
 class EndpointExistedInstruction:
-    endpoint: Endpoint
+    endpoint_path: str
 
 
 @dataclass(slots=True)
 class EndpointDidntExistInstruction:
-    endpoint: Endpoint
+    endpoint_path: str
 
 
 @dataclass(slots=True)
 class EndpointInstructionFactory:
-    endpoint: Endpoint
+    endpoint_path: str
 
     @property
     def didnt_exist(self) -> EndpointDidntExistInstruction:
-        return EndpointDidntExistInstruction(self.endpoint)
+        return EndpointDidntExistInstruction(self.endpoint_path)
 
     @property
     def existed(self) -> EndpointExistedInstruction:
-        return EndpointExistedInstruction(self.endpoint)
+        return EndpointExistedInstruction(self.endpoint_path)
 
     def had(
         self,
@@ -99,7 +99,7 @@ class EndpointInstructionFactory:
         generate_unique_id_function: Callable[[APIRoute], str] = Sentinel,
     ):
         return EndpointHadInstruction(
-            self.endpoint,
+            self.endpoint_path,
             EndpointAttributesPayload(
                 path=path,
                 status_code=status_code,
@@ -122,14 +122,8 @@ class EndpointInstructionFactory:
         )
 
 
-def endpoint(endpoint: Endpoint, /) -> EndpointInstructionFactory:
-    return EndpointInstructionFactory(endpoint)
+def endpoint(endpoint_path: str, /) -> EndpointInstructionFactory:
+    return EndpointInstructionFactory(endpoint_path)
 
 
-AlterEndpointSubInstruction = (
-    EndpointDidntExistInstruction
-    | EndpointExistedInstruction
-    | EndpointHadInstruction
-    # | EndpointDidntHaveDependencyInstruction
-    # | EndpointHadDependencyInstruction
-)
+AlterEndpointSubInstruction = EndpointDidntExistInstruction | EndpointExistedInstruction | EndpointHadInstruction

--- a/universi/structure/schemas.py
+++ b/universi/structure/schemas.py
@@ -2,7 +2,7 @@ import functools
 import inspect
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, ParamSpec, TypeVar, cast
+from typing import TYPE_CHECKING, Any, cast
 
 from pydantic import BaseModel
 
@@ -13,10 +13,6 @@ from .._utils import Sentinel
 
 if TYPE_CHECKING:
     from pydantic.typing import AbstractSetIntStr, MappingIntStrAny
-
-_SchemaInstance = TypeVar("_SchemaInstance", bound=Any)
-_R = TypeVar("_R")
-_P = ParamSpec("_P")
 
 
 @dataclass
@@ -74,7 +70,8 @@ class OldSchemaHadField:
 class AlterFieldInstructionFactory:
     schema: type[BaseModel]
     name: str
-    # TODO: Add a validation  to check that field actually changed
+    # TODO: Check if TODO below is still valid. I think, it's not.
+    # TODO: Add a validation to check that field actually changed
 
     def had(
         self,


### PR DESCRIPTION
#9 